### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,6 @@
 name: 测试构建
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/Xget-Now/security/code-scanning/4](https://github.com/xixu-me/Xget-Now/security/code-scanning/4)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents, so `contents: read` is sufficient. This can be set at the workflow level (top-level, applying to all jobs) or at the job level (under `test-build`). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made by adding the following block after the `name:` line and before the `on:` block in `.github/workflows/test-build.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
